### PR TITLE
fix(docker): correctly deploy Angular app in Docker image by targeting the 'browser' subdirectory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN npm run build --prod
 # Production environment
 FROM nginx:alpine
 COPY ./default.conf /etc/nginx/conf.d/
-COPY --from=builder /usr/src/app/dist/day32w-purchase-order /usr/share/nginx/html
+COPY --from=builder /usr/src/app/dist/day32w-purchase-order/browser /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
**Description**

This pull request addresses an issue where the Angular application was not displaying correctly when deployed via the Docker image. After building and running the container, the application did not load, and port 80 was displaying the default nginx page.

**Diagnosis**

1.  **Observed Behavior:** Angular app not loading when deployed via Docker.
2.  **Investigation:**
    *   Checked the `Dockerfile` and verified Nginx command via `CMD ["nginx", "-g", "daemon off;"]` which was to serve static files from `/usr/share/nginx/html`
    *   Executed `docker exec -it <container_id> /bin/sh` to enter the running container's shell.
    *   Inspected the `/usr/share/nginx/html` directory and found it contained the default nginx `index.html` file and a `browser/` directory.
    *   Navigated to `/usr/share/nginx/html/browser` within the container and discovered that the Angular application's HTML, CSS, and JavaScript files were located within.
3.  **Root Cause:** The `npm run build --prod` process was building the static assets into `/usr/src/app/dist/day32w-purchase-order/browser` instead of `/usr/src/app/dist/day32w-purchase-order`, so nginx wasn't serving the files from the correct location.

**Resolution**

The solution involves updating the `Dockerfile` to copy the contents of the `browser` subdirectory to Nginx's root directory. This will ensure that the relevant files are placed in the correct location for Nginx to serve.

The following change was made:

```diff
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@
 # Production environment
 FROM nginx:alpine
 COPY ./default.conf /etc/nginx/conf.d/
-COPY --from=builder /usr/src/app/dist/day32w-purchase-order /usr/share/nginx/html
+COPY --from=builder /usr/src/app/dist/day32w-purchase-order/browser /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
```

By changing the `COPY` command to `/usr/src/app/dist/day32w-purchase-order/browser /usr/share/nginx/html`, Nginx can now correctly locate and serve the Angular application.

**Testing**

The fix was verified by:

1. Building the Docker image with the updated `Dockerfile`.
2. Running a container from the image.
3. Accessing the application through port 80 in a web browser, confirming that the Angular application now loads correctly.